### PR TITLE
Add reuse mechanism for OpenSergoClient.

### DIFF
--- a/pkg/client/opensergo_client.go
+++ b/pkg/client/opensergo_client.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -68,6 +69,32 @@ func NewOpenSergoClient(host string, port uint32) (*OpenSergoClient, error) {
 	openSergoClient.subscribeConfigStreamObserverPtr.Store(&subscribeConfigStreamObserver{})
 	openSergoClient.subscribeConfigStreamStatus.Store(initial)
 	return openSergoClient, nil
+}
+
+var (
+	clientMu   sync.Mutex
+	clientPool = make(map[string]*OpenSergoClient)
+)
+
+// GetOpenSergoClientByPool returns an instance of OpenSergoClient from a pool, based on host:port,
+// if it doesn't exist, it will be created and reused for the next call.
+func GetOpenSergoClientByPool(host string, port uint32) (*OpenSergoClient, error) {
+	address := host + ":" + strconv.FormatUint(uint64(port), 10)
+
+	clientMu.Lock()
+	defer clientMu.Unlock()
+
+	if client, ok := clientPool[address]; ok {
+		return client, nil
+	}
+
+	client, err := NewOpenSergoClient(host, port)
+	if err != nil {
+		return nil, err
+	}
+	clientPool[address] = client
+
+	return client, nil
 }
 
 func (c *OpenSergoClient) SubscribeDataCache() *subscribe.SubscribeDataCache {

--- a/pkg/client/opensergo_client.go
+++ b/pkg/client/opensergo_client.go
@@ -76,9 +76,9 @@ var (
 	clientPool = make(map[string]*OpenSergoClient)
 )
 
-// GetOpenSergoClientByPool returns an instance of OpenSergoClient from a pool, based on host:port,
+// GetOpenSergoClientFromPool returns an instance of OpenSergoClient from a pool, based on host:port,
 // if it doesn't exist, it will be created and reused for the next call.
-func GetOpenSergoClientByPool(host string, port uint32) (*OpenSergoClient, error) {
+func GetOpenSergoClientFromPool(host string, port uint32) (*OpenSergoClient, error) {
 	address := host + ":" + strconv.FormatUint(uint64(port), 10)
 
 	clientMu.Lock()

--- a/samples/main/main.go
+++ b/samples/main/main.go
@@ -34,10 +34,10 @@ func main() {
 		logging.Error(err, "Failed to StartAndSubscribeOpenSergoConfig: %s\n")
 	}
 
-	err = StartAndSubscribeOpenSergoConfigByPool()
+	err = StartAndSubscribeOpenSergoConfigFromPool()
 	if err != nil {
 		// Handle error here.
-		logging.Error(err, "Failed to StartAndSubscribeOpenSergoConfigByPool: %s\n")
+		logging.Error(err, "Failed to StartAndSubscribeOpenSergoConfigFromPool: %s\n")
 	}
 
 	select {}
@@ -93,7 +93,7 @@ func StartAndSubscribeOpenSergoConfig() error {
 	return err
 }
 
-func StartAndSubscribeOpenSergoConfigByPool() error {
+func StartAndSubscribeOpenSergoConfigFromPool() error {
 	// Set OpenSergo console logger (optional)
 	consoleLogger := logging.NewConsoleLogger(logging.InfoLevel, logging.JsonFormat, true)
 	logging.AddLogger(consoleLogger)
@@ -102,7 +102,7 @@ func StartAndSubscribeOpenSergoConfigByPool() error {
 	//logging.AddLogger(fileLogger)
 
 	// Get a OpenSergoClient by pool.
-	openSergoClient, err := client.GetOpenSergoClientByPool("127.0.0.1", 10246)
+	openSergoClient, err := client.GetOpenSergoClientFromPool("127.0.0.1", 10246)
 	if err != nil {
 		return err
 	}

--- a/samples/main/main.go
+++ b/samples/main/main.go
@@ -34,6 +34,12 @@ func main() {
 		logging.Error(err, "Failed to StartAndSubscribeOpenSergoConfig: %s\n")
 	}
 
+	err = StartAndSubscribeOpenSergoConfigByPool()
+	if err != nil {
+		// Handle error here.
+		logging.Error(err, "Failed to StartAndSubscribeOpenSergoConfigByPool: %s\n")
+	}
+
 	select {}
 }
 
@@ -47,6 +53,56 @@ func StartAndSubscribeOpenSergoConfig() error {
 
 	// Create a OpenSergoClient.
 	openSergoClient, err := client.NewOpenSergoClient("127.0.0.1", 10246)
+	if err != nil {
+		return err
+	}
+
+	// Start OpenSergoClient
+	err = openSergoClient.Start()
+	if err != nil {
+		return err
+	}
+
+	// Create a SubscribeKey for FaultToleranceRule.
+	faultToleranceSubscribeKey := model.NewSubscribeKey("default", "foo-app", configkind.ConfigKindRefFaultToleranceRule{})
+	// Create a Subscriber.
+	sampleFaultToleranceRuleSubscriber := &samples.SampleFaultToleranceRuleSubscriber{}
+	// Subscribe data with the key and subscriber.
+	err = openSergoClient.SubscribeConfig(*faultToleranceSubscribeKey, api.WithSubscriber(sampleFaultToleranceRuleSubscriber))
+	if err != nil {
+		return err
+	}
+
+	// Create a SubscribeKey for RateLimitStrategy.
+	rateLimitSubscribeKey := model.NewSubscribeKey("default", "foo-app", configkind.ConfigKindRefRateLimitStrategy{})
+	// Create another Subscriber.
+	sampleRateLimitStrategySubscriber := &samples.SampleRateLimitStrategySubscriber{}
+	// Subscribe data with the key and subscriber.
+	err = openSergoClient.SubscribeConfig(*rateLimitSubscribeKey, api.WithSubscriber(sampleRateLimitStrategySubscriber))
+
+	if err != nil {
+		return err
+	}
+	// Create a SubscribeKey for TrafficRouter
+	trafficRouterSubscribeKey := model.NewSubscribeKey("default", "service-provider", configkind.ConfigKindTrafficRouterStrategy{})
+	// Create another Subscriber
+	sampleTrafficRouterSubscriber := &samples.SampleTrafficRouterSubscriber{}
+	// Subscribe data with the key and subscriber
+	err = openSergoClient.SubscribeConfig(*trafficRouterSubscribeKey, api.WithSubscriber(sampleTrafficRouterSubscriber))
+
+	return err
+}
+
+func StartAndSubscribeOpenSergoConfigByPool() error {
+	// Set OpenSergo console logger (optional)
+	consoleLogger := logging.NewConsoleLogger(logging.InfoLevel, logging.JsonFormat, true)
+	logging.AddLogger(consoleLogger)
+	// Set OpenSergo file logger (optional)
+	// fileLogger := logging.NewFileLogger("./opensergo-universal-transport-service.log", logging.InfoLevel, logging.JsonFormat, true)
+	//logging.AddLogger(fileLogger)
+
+	// Get a OpenSergoClient by pool.
+	openSergoClient, err := client.GetOpenSergoClientByPool("127.0.0.1", 10246)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Describe what this PR does / why we need it
Add reuse mechanism for OpenSergoClient.

### Does this pull request fix one issue?
Fixes https://github.com/opensergo/opensergo-go-sdk/issues/31

### Describe how you did it
I use a map with host:port as key and openSergoClient as value to control reuse, and use sync.map to avoid concurrent access problems.

### Describe how to verify it
He looks like `NewOpenSergoClient`, I added a `StartAndSubscribeOpenSergoConfigFromPool` function in `samples/main/main.go`.

### Special notes for reviews
nothing.